### PR TITLE
Revert "Queue up attempts rather than running them all at once"

### DIFF
--- a/lib/database/attempt.ex
+++ b/lib/database/attempt.ex
@@ -19,33 +19,24 @@ defmodule BorsNG.Database.Attempt do
     field(:state, AttemptState)
     field(:last_polled, :integer)
     field(:timeout_at, :integer)
-    field(:arguments, :string)
     timestamps()
   end
 
   @spec new(Patch.t(), String.t()) :: t
-  def new(%Patch{} = patch, arguments) do
+  def new(%Patch{} = patch) do
     %Attempt{
       patch_id: patch.id,
-      patch: patch,
       into_branch: patch.into_branch,
       commit: nil,
       state: 0,
-      arguments: arguments,
       last_polled: DateTime.to_unix(DateTime.utc_now(), :second)
     }
   end
 
-  @spec all(AttemptState.t() | :incomplete) :: Ecto.Queryable.t()
+  @spec all(:incomplete) :: Ecto.Queryable.t()
   def all(:incomplete) do
     from(b in Attempt,
       where: b.state == 0 or b.state == 1
-    )
-  end
-
-  def all(state) do
-    from(b in Attempt,
-      where: b.state == ^state
     )
   end
 


### PR DESCRIPTION
This reverts commit 3d6804158919be0daad4379d2a0e094ff31e5239.

Conflicts:
    lib/database/attempt.ex
    lib/worker/attemptor.ex

Resolved conflicts with Brandon